### PR TITLE
Add deployment permissions for GitHub Pages

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,11 +6,6 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: 'pages'
   cancel-in-progress: false
@@ -18,6 +13,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,17 +43,26 @@ jobs:
         run: npm run lint
       - name: Build with Next.js
         run: npm run build
+      - name: Fix permissions for Github Pages
+        run: |
+          chmod -c -R +rX "out/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./out
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   prepare:
     name: Setup dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       hasRelease: ${{ steps.set_output.outputs.hasRelease }}
     steps:


### PR DESCRIPTION
This pull request adds the necessary permissions for deploying to GitHub Pages. It also includes a fix for file permissions in the build step.