### PR TITLE
Use deploy key to allow triggering other workflows

### DIFF
--- a/.changeset/loud-forks-guess.md
+++ b/.changeset/loud-forks-guess.md
@@ -1,0 +1,5 @@
+---
+"pho3nixf1re.net": patch
+---
+
+allow workflows to trigger other workflows

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: '${{ secrets.COMMIT_KEY }}'
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This pull request adds the use of a deploy key to allow triggering other workflows. It also enables branch protection.