### PR TITLE
Simplify logic to block deploys on PRs

### DIFF
--- a/.changeset/breezy-chicken-tickle.md
+++ b/.changeset/breezy-chicken-tickle.md
@@ -1,0 +1,5 @@
+---
+"pho3nixf1re.net": patch
+---
+
+simplify logic to block deploys on PRs

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -55,9 +55,7 @@ jobs:
           path: ./out
 
   deploy:
-    if:
-      github.event_name != 'pull_request' && startsWith(github.ref,
-      'refs/tags/v')
+    if: startsWith(github.ref,'refs/tags/v')
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,15 @@ jobs:
     name: Setup dependencies
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ssh-key: '${{ secrets.COMMIT_KEY }}'
+          token: ${{ secrets.PAT }}
       - name: Configure git author
         run: |
+          git config --unset http.https://github.com/.extraheader
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Setup Node.js


### PR DESCRIPTION
This pull request simplifies the logic to block deploys on pull requests. It removes unnecessary conditions and improves the readability of the code.